### PR TITLE
Connection script feature from config.yaml

### DIFF
--- a/sqlbucket/__init__.py
+++ b/sqlbucket/__init__.py
@@ -1,6 +1,6 @@
 
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 
 from sqlbucket.core import SQLBucket

--- a/sqlbucket/integrity.py
+++ b/sqlbucket/integrity.py
@@ -12,7 +12,7 @@ def run_integrity(configuration: dict, prefix: str = ''):
         f'Starting integrity checks for {configuration["project_name"]} '
         f'with connection {configuration["connection_name"]}'
     )
-    connection = create_connection(configuration["connection_url"])
+    connection = create_connection(configuration)
     for query_name in configuration["order"]:
 
         if not query_name.startswith(prefix):

--- a/sqlbucket/project.py
+++ b/sqlbucket/project.py
@@ -72,7 +72,7 @@ class Project:
             "connection_url": self.connection_url,
             "connection_name": self.connection_name,
             "project_name": str(self.project_path).split('/')[-1],
-            "connection_script": self.get_connection_query()
+            "connection_query": self.get_connection_query()
         }
 
     def configure_integrity(self) -> dict:
@@ -98,7 +98,7 @@ class Project:
             "connection_url": self.connection_url,
             "connection_name": self.connection_name,
             "project_name": str(self.project_path).split('/')[-1],
-            "connection_script": self.get_connection_query()
+            "connection_query": self.get_connection_query()
         }
 
     def run(self, group: str = None, from_step: int = 1,
@@ -131,7 +131,7 @@ class Project:
         :return: the connection query if any.
         """
 
-        if "connection_script" not in self.project_config:
+        if "connection_query" not in self.project_config:
             return None
 
         queries_path = (Path(self.project_path) / 'queries').resolve()
@@ -142,7 +142,7 @@ class Project:
             searchpath=search_path
         ))
         template = jinja_env.get_template(
-            self.project_config['connection_script']
+            self.project_config['connection_query']
         )
         return template.render(**self.context)
 

--- a/sqlbucket/runners.py
+++ b/sqlbucket/runners.py
@@ -25,7 +25,7 @@ class ProjectRunner:
         self.starting_logs()
 
         start = datetime.now()
-        connection = create_connection(self.configuration["connection_url"])
+        connection = create_connection(self.configuration)
         for i, query in enumerate(self.configuration["order"]):
 
             # we skip the queries out of index
@@ -70,11 +70,16 @@ class ProjectRunner:
         logger.info(f"Project completed in {end - start}")
 
 
-def create_connection(connection_url: str) -> Connection:
+def create_connection(configuration: dict) -> Connection:
     engine = create_engine(
-        connection_url,
+        configuration['connection_url'],
         poolclass=NullPool,
         isolation_level="AUTOCOMMIT"
     )
     connection = engine.connect()
+    if configuration.get('connection_script') is not None:
+        logger.info(f'Running connection script: '
+                    f'{configuration["connection_script"]}')
+        connection.execute(text(configuration['connection_script']))
+
     return connection

--- a/sqlbucket/runners.py
+++ b/sqlbucket/runners.py
@@ -77,9 +77,9 @@ def create_connection(configuration: dict) -> Connection:
         isolation_level="AUTOCOMMIT"
     )
     connection = engine.connect()
-    if configuration.get('connection_script') is not None:
-        logger.info(f'Running connection script: '
-                    f'{configuration["connection_script"]}')
-        connection.execute(text(configuration['connection_script']))
+    if configuration.get('connection_query') is not None:
+        logger.info(f'Running connection query: '
+                    f'{configuration["connection_query"]}')
+        connection.execute(text(configuration['connection_query']))
 
     return connection

--- a/tests/fixtures/projects/project2/config.yaml
+++ b/tests/fixtures/projects/project2/config.yaml
@@ -6,7 +6,7 @@ order:
     - folder1/query_three.sql
 
 
-connection_script: connect_query.sql
+connection_query: connect_query.sql
 
 
 project_variables:

--- a/tests/fixtures/projects/project2/config.yaml
+++ b/tests/fixtures/projects/project2/config.yaml
@@ -6,6 +6,9 @@ order:
     - folder1/query_three.sql
 
 
+connection_script: connect_query.sql
+
+
 project_variables:
   foo: barbar
 

--- a/tests/fixtures/projects/project2/queries/connect_query.sql
+++ b/tests/fixtures/projects/project2/queries/connect_query.sql
@@ -1,0 +1,1 @@
+set search_path to {{ c.destination_schema }}, {{ c.source_schema }};

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -201,15 +201,19 @@ class TestConnectScript:
     )
     configuration = project.configure()
     integrity_configuration = project.configure_integrity()
+    expected_query = 'set search_path to output_schema, input_schema;'
 
     def test_etl_configuration_with_connect_script(self):
-        assert 'connection_script' in self.configuration
+        assert 'connection_query' in self.configuration
 
     def test_integrity_configuration_with_connect_script(self):
-        assert 'connection_script' in self.integrity_configuration
+        assert 'connection_query' in self.integrity_configuration
 
-    def test_connect_script_query(self):
+    def test_connect_query_etl(self):
+        assert self.configuration['connection_query'] == self.expected_query
+
+    def test_connect_query_integrity(self):
         expected_query = 'set search_path to output_schema, input_schema;'
-        assert self.configuration['connection_script'] == expected_query
-        assert self.integrity_configuration['connection_script'] == expected_query
+        assert self.integrity_configuration['connection_query'] == self.expected_query
+
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -181,3 +181,35 @@ class TestProjectOrderExceptions:
         )
         with pytest.raises(OrderNotInRightFormat):
             project.configure(group='main')
+
+
+class TestConnectScript:
+
+    path = str(
+        (Path(__file__).parent / Path('fixtures/projects/project2')))
+    project = Project(
+        project_path=path,
+        connection_url='something://database',
+        context={
+            'c': {
+                'name': 'db',
+                'destination_schema': 'output_schema',
+                'source_schema': 'input_schema'
+            },
+            'e': {'name': 'dev'}
+        }
+    )
+    configuration = project.configure()
+    integrity_configuration = project.configure_integrity()
+
+    def test_etl_configuration_with_connect_script(self):
+        assert 'connection_script' in self.configuration
+
+    def test_integrity_configuration_with_connect_script(self):
+        assert 'connection_script' in self.integrity_configuration
+
+    def test_connect_script_query(self):
+        expected_query = 'set search_path to output_schema, input_schema;'
+        assert self.configuration['connection_script'] == expected_query
+        assert self.integrity_configuration['connection_script'] == expected_query
+


### PR DESCRIPTION
We can now set a connection script by simply set it in the config.yaml as:

```yaml
connection_script: my_connection_query.sql
```

It will be ran right after creating a connection, and before running ETL or integrity queries.