### PR TITLE
Integrity 0 rows

### DIFF
--- a/sqlbucket/__init__.py
+++ b/sqlbucket/__init__.py
@@ -1,6 +1,6 @@
 
 
-__version__ = "0.2.12dev3"
+__version__ = "0.3.0"
 
 
 from sqlbucket.core import SQLBucket

--- a/sqlbucket/__init__.py
+++ b/sqlbucket/__init__.py
@@ -1,6 +1,6 @@
 
 
-__version__ = "0.2.11"
+__version__ = "0.2.12dev3"
 
 
 from sqlbucket.core import SQLBucket


### PR DESCRIPTION
Quick fix when an integrity check returns 0 rows (very occasion but it can happen when both source and target have no data).

Also quick fix on logging.