### PR TITLE
Configure isolation level as a parameter.

### DIFF
--- a/documentation/cli.rst
+++ b/documentation/cli.rst
@@ -76,6 +76,8 @@ Command: run-job
 +--------------------+--------------+-------------------------------------------------------------------------+
 | ``--group``        | ``-g``       |  Name of the group to run from the ``order`` attribute in config.yaml   |
 +--------------------+--------------+-------------------------------------------------------------------------+
+| ``--isolation``    | ``-i``       |  Set isolation level in case default from DB is not what you want       |
++--------------------+--------------+-------------------------------------------------------------------------+
 | ``--verbose``      | ``-v``       |  Show queries in terminal before running them                           |
 +--------------------+--------------+-------------------------------------------------------------------------+
 | ``--render``       | ``-r``       |  Will only render and print the queries in terminal without running them|

--- a/sqlbucket/__init__.py
+++ b/sqlbucket/__init__.py
@@ -1,7 +1,6 @@
 
 
-
-__version__ = "0.3.3.dev0"
+__version__ = "0.3.3.dev1"
 
 
 from sqlbucket.core import SQLBucket

--- a/sqlbucket/__init__.py
+++ b/sqlbucket/__init__.py
@@ -1,6 +1,6 @@
 
 
-__version__ = "0.3.3.dev1"
+__version__ = "0.3.3.dev3"
 
 
 from sqlbucket.core import SQLBucket

--- a/sqlbucket/cli.py
+++ b/sqlbucket/cli.py
@@ -30,6 +30,7 @@ def load_cli(sqlbucket_object):
     @click.option('--from_days', '-fd', required=False, default=None, type=str)
     @click.option('--to_days', '-td', required=False, default=None, type=str)
     @click.option('--group', '-g', required=False, type=str)
+    @click.option('--isolation_level', '-i', required=False, default=None, type=str)
     @click.option('--verbose', '-v', is_flag=True, help="Print queries")
     @click.option('--rendering', '-r', is_flag=True, help="Only render queries")
     @click.option('--all', '-all', is_flag=True, help="All dbs")
@@ -37,7 +38,8 @@ def load_cli(sqlbucket_object):
     @click.pass_obj
     @click.argument('args', nargs=-1)
     def run_job(sqlbucket, name, db, fstep, tstep, to_date, from_date,
-                from_days, to_days, group, verbose, rendering, all, edb, args):
+                from_days, to_days, group, isolation_level, verbose, rendering,
+                all, edb, args):
 
         submitted_variables = cli_variables_parser(args)
 
@@ -52,6 +54,9 @@ def load_cli(sqlbucket_object):
 
         logger.info('Variables used')
         logger.info(submitted_variables)
+
+        if isolation_level:
+            isolation_level = isolation_level.upper()
 
         # included dbs
         if db:
@@ -76,7 +81,11 @@ def load_cli(sqlbucket_object):
                 etl.render(from_step=fstep, to_step=tstep, group=group)
             else:
                 etl.run(
-                    from_step=fstep, to_step=tstep, group=group, verbose=verbose
+                    from_step=fstep,
+                    to_step=tstep,
+                    group=group,
+                    verbose=verbose,
+                    isolation_level=isolation_level
                 )
 
     @cli.command(context_settings=dict(ignore_unknown_options=True))

--- a/sqlbucket/cli.py
+++ b/sqlbucket/cli.py
@@ -30,7 +30,7 @@ def load_cli(sqlbucket_object):
     @click.option('--from_days', '-fd', required=False, default=None, type=str)
     @click.option('--to_days', '-td', required=False, default=None, type=str)
     @click.option('--group', '-g', required=False, type=str)
-    @click.option('--isolation_level', '-i', required=False, default=None, type=str)
+    @click.option('--isolation', '-i', required=False, default=None, type=str)
     @click.option('--verbose', '-v', is_flag=True, help="Print queries")
     @click.option('--rendering', '-r', is_flag=True, help="Only render queries")
     @click.option('--all', '-all', is_flag=True, help="All dbs")
@@ -38,7 +38,7 @@ def load_cli(sqlbucket_object):
     @click.pass_obj
     @click.argument('args', nargs=-1)
     def run_job(sqlbucket, name, db, fstep, tstep, to_date, from_date,
-                from_days, to_days, group, isolation_level, verbose, rendering,
+                from_days, to_days, group, isolation, verbose, rendering,
                 all, edb, args):
 
         submitted_variables = cli_variables_parser(args)
@@ -55,8 +55,8 @@ def load_cli(sqlbucket_object):
         logger.info('Variables used')
         logger.info(submitted_variables)
 
-        if isolation_level:
-            isolation_level = isolation_level.upper()
+        if isolation:
+            isolation = isolation.upper()
 
         # included dbs
         if db:
@@ -85,7 +85,7 @@ def load_cli(sqlbucket_object):
                     to_step=tstep,
                     group=group,
                     verbose=verbose,
-                    isolation_level=isolation_level
+                    isolation_level=isolation
                 )
 
     @cli.command(context_settings=dict(ignore_unknown_options=True))

--- a/sqlbucket/project.py
+++ b/sqlbucket/project.py
@@ -90,13 +90,14 @@ class Project:
         }
 
     def run(self, group: str = None, from_step: int = 1, to_step: int = None,
-            verbose: bool = False) -> None:
+            verbose: bool = False, isolation_level: str = None) -> None:
         configuration = self.configure(group)
         runner = ProjectRunner(
             configuration=configuration,
             from_step=from_step,
             to_step=to_step,
-            verbose=verbose
+            verbose=verbose,
+            isolation_level=isolation_level
         )
         runner.run_project()
 

--- a/sqlbucket/runners.py
+++ b/sqlbucket/runners.py
@@ -12,7 +12,8 @@ class ProjectRunner:
         configuration: dict,
         from_step: int = 1,
         to_step: int = None,
-        verbose: bool = False
+        verbose: bool = False,
+        isolation_level: str = None
     ):
         self.configuration = configuration
         self.from_step_index = from_step - 1
@@ -22,6 +23,7 @@ class ProjectRunner:
         if self.from_step_index > self.to_step_index:
             raise Exception('Start step must be lower or equal the final step')
 
+        self.isolation_level = isolation_level
         self.verbose = verbose
 
     def render_queries(self) -> None:
@@ -38,7 +40,10 @@ class ProjectRunner:
         self.starting_logs()
 
         start = datetime.now()
-        connection = create_connection(self.configuration)
+        connection = create_connection(
+            self.configuration, isolation_level=self.isolation_level
+        )
+        
         for i, query in enumerate(self.configuration["order"]):
 
             # we skip the queries out of index
@@ -84,23 +89,24 @@ class ProjectRunner:
         logger.info(f"Project completed in {end - start}")
 
 
-def create_connection(configuration: dict) -> Connection:
-    # todo: isolation parameter consider possibility to set different isolation
-    #  level.
+def create_connection(configuration: dict, isolation_level: str) -> Connection:
     # todo: a user may prefer to run a session that commits data only at the
     #  very end of the ETL instead of an auto commit execution at engine level.
 
-    isolation_level = "AUTOCOMMIT"
-
-    # SQLITE does not have autocommit, so we set to a more
-    if configuration['connection_url'][:6] == 'sqlite':
-        isolation_level = 'SERIALIZABLE'
-
-    engine = create_engine(
-        configuration['connection_url'],
-        poolclass=NullPool,
-        isolation_level=isolation_level
-    )
+    # if no isolation level is indicated, we just create an engine without the
+    # isolation level parameter. This means it will use the default one.
+    # Check your backend DB documentation to know which one is the default as
+    # it varies between databases.
+    if not isolation_level:
+        engine = create_engine(
+            configuration['connection_url'], poolclass=NullPool
+        )
+    else:
+        engine = create_engine(
+            configuration['connection_url'],
+            poolclass=NullPool,
+            isolation_level=isolation_level
+        )
     connection = engine.connect()
     if configuration.get('connection_query') is not None:
         logger.info(f'Running connection query: '

--- a/sqlbucket/runners.py
+++ b/sqlbucket/runners.py
@@ -43,7 +43,7 @@ class ProjectRunner:
         connection = create_connection(
             self.configuration, isolation_level=self.isolation_level
         )
-        
+
         for i, query in enumerate(self.configuration["order"]):
 
             # we skip the queries out of index
@@ -89,7 +89,8 @@ class ProjectRunner:
         logger.info(f"Project completed in {end - start}")
 
 
-def create_connection(configuration: dict, isolation_level: str) -> Connection:
+def create_connection(
+        configuration: dict, isolation_level: str = None) -> Connection:
     # todo: a user may prefer to run a session that commits data only at the
     #  very end of the ETL instead of an auto commit execution at engine level.
 


### PR DESCRIPTION
It used to set the isolation level AUTOCOMMIT everywhere. This isolation level unfortunately is irrelevant for most databases.
The isolation level is now optional, which means if not configured, the SQL engine will apply the default isolation of your backend database. You can now set the isolation level of your choice however  when running a project. Also added a new parameter to CLI to reflect this new parameter.