### PR TITLE
Fix when running integrity and query fails

### DIFF
--- a/sqlbucket/integrity.py
+++ b/sqlbucket/integrity.py
@@ -1,4 +1,4 @@
-from sqlbucket.runners import create_connection
+from sqlbucket.runners import create_connection, connection_query
 from sqlbucket.runners import logger
 from tabulate import tabulate
 from sqlbucket.utils import integrity_logo, success
@@ -42,6 +42,7 @@ def run_integrity(configuration: dict, prefix: str = '', verbose: bool = False):
             errors += 1
             logger.info(f'Query {query_name} encountered an error:')
             logger.error(e)
+            connection_query(configuration, connection)
             continue
 
     # logging summary

--- a/sqlbucket/runners.py
+++ b/sqlbucket/runners.py
@@ -109,9 +109,13 @@ def create_connection(
             isolation_level=isolation_level
         )
     connection = engine.connect()
+    connection_query(configuration, connection)
+
+    return connection
+
+
+def connection_query(configuration: dict, connection: Connection):
     if configuration.get('connection_query') is not None:
         logger.info(f'Running connection query: '
                     f'{configuration["connection_query"]}')
         connection.execute(text(configuration['connection_query']))
-
-    return connection


### PR DESCRIPTION
When running integrity queries, if one of the queries fails, subsequent queries also fail because the search_path get lost after the failure. This fix reloads the search_path when a query is not execute successfully.