### PR TITLE
fix(macro): Fixed macro "are_within_threshold"

### DIFF
--- a/sqlbucket/macros/common.jinja2
+++ b/sqlbucket/macros/common.jinja2
@@ -66,7 +66,7 @@ from {{ table }}
 
 {% macro are_within_threshold(scalar_a, scalar_b, threshold, integrity_check_name=None) %}
 select
-    {% if not integrity_check_name %}'source_to_target_integrity_check{% else %}{{ integrity_check_name }}{% endif %} as integrity_check
+    {% if not integrity_check_name %}'source_to_target_integrity_check'{% else %}{{ integrity_check_name }}{% endif %} as integrity_check,
     ({{ scalar_a }}) as expected,
     ({{ scalar_b }}) as calculated,
     abs((({{ scalar_a }}) - ({{ scalar_b }})) / nullif(({{ scalar_b }}), 0)) <= {{ threshold }}


### PR DESCRIPTION
In the first line of the select there was a quote and a comma missing that made this macro not-usable