### PR TITLE
Feature/message hook

### DIFF
--- a/sqlbucket/__init__.py
+++ b/sqlbucket/__init__.py
@@ -1,8 +1,7 @@
 
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 
 from sqlbucket.core import SQLBucket
 from sqlbucket.project import Project
-

--- a/sqlbucket/cli.py
+++ b/sqlbucket/cli.py
@@ -35,11 +35,13 @@ def load_cli(sqlbucket_object):
     @click.option('--rendering', '-r', is_flag=True, help="Only render queries")
     @click.option('--all', '-all', is_flag=True, help="All dbs")
     @click.option('--edb', '-x', required=False, type=str, help="Excluded dbs")
+    @click.option('--silent', '-s', required=False, is_flag=True, default=False,
+                  help="Do not notify execution status.")
     @click.pass_obj
     @click.argument('args', nargs=-1)
     def run_job(sqlbucket, name, db, fstep, tstep, to_date, from_date,
                 from_days, to_days, group, isolation, verbose, rendering,
-                all, edb, args):
+                all, edb, silent, args):
 
         submitted_variables = cli_variables_parser(args)
 
@@ -90,7 +92,8 @@ def load_cli(sqlbucket_object):
                     to_step=tstep,
                     group=group,
                     verbose=verbose,
-                    isolation_level=isolation
+                    isolation_level=isolation,
+                    silent=silent
                 )
 
     @cli.command(context_settings=dict(ignore_unknown_options=True))

--- a/sqlbucket/project.py
+++ b/sqlbucket/project.py
@@ -89,6 +89,30 @@ class Project:
             "connection_query": self.get_connection_query()
         }
 
+    def send_msg(run_func):
+
+        def wrapper(self, *args, **kwargs):
+
+            silent = kwargs.pop("silent", False)
+
+            if silent:
+                run_func(self, *args, **kwargs)
+            else:
+                group = kwargs.get("group")
+                config = self.configure(group)
+
+                if 'context' in config and 'f' in config['context']:
+                    funcs_reg = config['context']['f']
+                    start_msg = funcs_reg.get('start_msg')
+                    end_msg = funcs_reg.get('end_msg')
+
+                    if start_msg: start_msg(**config)
+                    run_func(self, *args, **kwargs)
+                    if end_msg: end_msg(**config)
+
+        return wrapper
+
+    @send_msg
     def run(self, group: str = None, from_step: int = 1, to_step: int = None,
             verbose: bool = False, isolation_level: str = None) -> None:
         configuration = self.configure(group)

--- a/sqlbucket/project.py
+++ b/sqlbucket/project.py
@@ -106,9 +106,14 @@ class Project:
                     start_msg = funcs_reg.get('start_msg')
                     end_msg = funcs_reg.get('end_msg')
 
-                    if start_msg: start_msg(**config)
-                    run_func(self, *args, **kwargs)
-                    if end_msg: end_msg(**config)
+                    try:
+                        if start_msg: start_msg(**config)
+                        run_func(self, *args, **kwargs)
+                        if end_msg: end_msg(**config)
+                    except:
+                        exception_msg = funcs_reg.get('exception_msg')
+                        if exception_msg: exception_msg(**config)
+                        raise
 
         return wrapper
 


### PR DESCRIPTION
Hello,

A nice thing to have would be some kind of pre/post-hook that send a (custom) message before the execution of a project. 

This message could be anything, a chat message, an e-mail, etc

This PR is for this purpose, it implements a new method `send_msg` inside the `Project` class, this method is essentially a decorator for the `run` method that allows to pass a start/end function before/after the actual execution to send a message. Also allows to pass a function to handle an exception and send a message.

Some considerations:
- functions *must* be called `start_msg` and `end_msg` respectively, otherwise msg would have no effect.
- function for sending exception msg *must* be called `exception_msg`.
- these functions are passed trough the usual mechanism in the `SQLBucket` class init or trough the method `register_function` of the same class.
- The config of the class is also passed to this functions, this is interesting when formatting a message to include project name, execution range etc. The usage inside this functions is optional anyway.
- A silent flag is added in the cli, in case start/end_msg functions are defined in the project but wants to be silent.

There is no problem in adding any further documentation 🙂 

